### PR TITLE
Include optional old_value parameter for listeners

### DIFF
--- a/src/ReplicatedStorage/ReplicaController.lua
+++ b/src/ReplicatedStorage/ReplicaController.lua
@@ -547,7 +547,7 @@ local function ReplicaSetValue(replica_id, path_array, value)
 		if listeners ~= nil then
 			if listeners[2] ~= nil then -- "Change" listeners
 				for _, listener in ipairs(listeners[2]) do
-					listener(value)
+					listener(value, old_value)
 				end
 			end
 		end
@@ -587,7 +587,7 @@ local function ReplicaSetValues(replica_id, path_array, values)
 			if listeners ~= nil then
 				if listeners[2] ~= nil then -- "Change" listeners
 					for _, listener in ipairs(listeners[2]) do
-						listener(value)
+						listener(value, old_value)
 					end
 				end
 			end


### PR DESCRIPTION
This change allows for the `listener` function passed to `Replica:ListenToChange(path, listener)` to take in an optional second parameter that is the `old_value`, and allows for a way to view and add functionality to the change in the value.