### PR TITLE
Add new_index to raw listener for ArrayInsert

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -649,7 +649,7 @@ Possible parameter reference for `Replica:ListenToRaw()`:
 ```lua
 -- ("SetValue", path_array, value)
 -- ("SetValues", path_array, values)
--- ("ArrayInsert", path_array, value)
+-- ("ArrayInsert", path_array, value, new_index)
 -- ("ArraySet", path_array, index, value)
 -- ("ArrayRemove", path_array, index, old_value)
 

--- a/src/ReplicatedStorage/ReplicaController.lua
+++ b/src/ReplicatedStorage/ReplicaController.lua
@@ -624,7 +624,7 @@ local function ReplicaArrayInsert(replica_id, path_array, value) --> new_index
 	end
 	-- Raw listeners:
 	for _, listener in ipairs(replica._raw_listeners) do
-		listener("ArrayInsert", path_array, value)
+		listener("ArrayInsert", path_array, value, new_index)
 	end
 	return new_index
 end


### PR DESCRIPTION
``Replica:ListenToArrayInsert(path, listener)`` currently sets up a listener which calls a function with parameters ``(new_index, new_value)``. This is missing from the raw listener; it currently calls a function with parameters ``("ArrayInsert", path_array, value)``

This will update the raw listener to be called with an additional parameter for ``new_index``, in which the overall call would look like: ``("ArrayInsert", path_array, value, new_index)``. Because it would be an additional parameter at the end of the call, it would not require any code changes from people currently using ReplicaService.

For reference, ``Replica:ListenToArrayRemove(path, listener)`` sets up a listener which calls a function with parameters ``(old_index, old_value)``. This feature also exists in the raw listener in which it calls a function with parameters ``("ArrayRemove", path_array, index, old_value)``