### PR TITLE
Improved handling of class tokens

### DIFF
--- a/src/ServerScriptService/ReplicaService.lua
+++ b/src/ServerScriptService/ReplicaService.lua
@@ -808,6 +808,8 @@ function Replica:Destroy()
 			rev_ReplicaDestroy:FireClient(player, id)
 		end
 	end
+	local class_name = self.Class
+	CreatedClassTokens[class_name] = false
 	-- Recursive destruction
 	DestroyReplicaAndDescendantsRecursive(self)
 end
@@ -825,6 +827,18 @@ function ReplicaService.NewClassToken(class_name) --> [ReplicaClassToken]
 	return {
 		Class = class_name
 	}
+end
+
+function ReplicaService.ReturnClassToken(class_name) --> [ReplicaClassToken]
+	if type(class_name) ~= "string" then
+		error("[ReplicaService]: class_name must be a string")
+	end
+
+	if CreatedClassTokens[class_name] == true then
+		return {
+			Class = class_name
+		}
+	end
 end
 
 function ReplicaService.NewReplica(replica_params) --> [Replica]


### PR DESCRIPTION
Proposed method of ReplicaService.ReturnClassToken as a way of checking whether a ClassToken already exists
Proposed clearing class token names when replicas are destroyed, because class tokens are supposed to be unique to the replica and the token is not used when the replica is destroyed

(Context: use case that inspired this was a project where replicas are assigned to the player when they join ex:  ClassToken = ReplicaService.NewClassToken(Replica_[playername])" and when they leave the replica is destroyed. If the player rejoins the game, an error occurs, because the class token already exists.  Two proposed methods, one to check if a class token exists by retrieving it and the other to remove class tokens from internal table when replicas are destroyed)